### PR TITLE
Add $RAC External incentives contracts to Junoswap assetlist

### DIFF
--- a/rewards_list.json
+++ b/rewards_list.json
@@ -90,6 +90,23 @@
           "decimals": 6
         }
       ]
+    },
+    {
+      "token_address": "",
+      "swap_address": "juno1e8n6ch7msks487ecznyeagmzd5ml2pq9tgedqt2u63vra0q0r9mqrjy6ys",
+      "rewards_tokens": [
+        {
+          "rewards_address": "juno1f75lut5uvgh39zvzgqpskgr5llg2uk6kzhy2u2znyuwlgrvdjfyscytnvd",
+          "token_address": "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
+          "swap_address": "juno1e8n6ch7msks487ecznyeagmzd5ml2pq9tgedqt2u63vra0q0r9mqrjy6ys",
+          "symbol": "RAC",
+          "name": "RAC",
+          "logoURI": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/racoon.png",
+          "native": false,
+          "denom": "rac",
+          "decimals": 6
+        }
+      ]
     }
   ]
 }

--- a/token_list.json
+++ b/token_list.json
@@ -342,6 +342,7 @@
       "chain_id": "juno-1",
       "token_address": "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
       "swap_address": "juno1m08vn7klzxh9tmqwajuux202xms2qz3uckle7zvtturcq7vk2yaqpcwxlz",
+      "staking_address": "juno185wfgaxx2n9mmyurj5ssawm2grggdf8wnsp3cw6rn6fs8ljsl87sx7xm68",
       "symbol": "RAC",
       "name": "RAC",
       "decimals": 6,


### PR DESCRIPTION
Added our staking and external incentives contracts below.

As of now we used the same approach as you guys did for Raw incentives. 

There is only 2 $RAC in the incentives for now and we will fund about 10k $RAC when we can have it in your interface. We are aiming an APR of 150% at the beginning for the first 2 weeks.