### PR TITLE
Correct coingecko id for USDC

### DIFF
--- a/pools_list.json
+++ b/pools_list.json
@@ -162,7 +162,7 @@
                "denom":"ujuno"
             },
             {
-               "id":"usdc",
+               "id":"usd-coin",
                "chain_id":"juno-1",
                "token_address":"",
                "symbol":"USDC",


### PR DESCRIPTION
This PR changes the id from USDC to `usd-coin` which is the correct coingecko id. This allows the correct price to be pulled for USDC.

https://www.coingecko.com/en/coins/usd-coin